### PR TITLE
Remove extraneous semicolons in zstd_internal.h

### DIFF
--- a/lib/common/zstd_internal.h
+++ b/lib/common/zstd_internal.h
@@ -203,10 +203,10 @@ typedef struct {
     #include ".debug/zstd_stats.h"
 #else
     typedef struct { U32  unused; } ZSTD_stats_t;
-    MEM_STATIC void ZSTD_statsPrint(ZSTD_stats_t* stats, U32 searchLength) { (void)stats; (void)searchLength; };
-    MEM_STATIC void ZSTD_statsInit(ZSTD_stats_t* stats) { (void)stats; };
-    MEM_STATIC void ZSTD_statsResetFreqs(ZSTD_stats_t* stats) { (void)stats; };
-    MEM_STATIC void ZSTD_statsUpdatePrices(ZSTD_stats_t* stats, size_t litLength, const BYTE* literals, size_t offset, size_t matchLength) { (void)stats; (void)litLength; (void)literals; (void)offset; (void)matchLength; };
+    MEM_STATIC void ZSTD_statsPrint(ZSTD_stats_t* stats, U32 searchLength) { (void)stats; (void)searchLength; }
+    MEM_STATIC void ZSTD_statsInit(ZSTD_stats_t* stats) { (void)stats; }
+    MEM_STATIC void ZSTD_statsResetFreqs(ZSTD_stats_t* stats) { (void)stats; }
+    MEM_STATIC void ZSTD_statsUpdatePrices(ZSTD_stats_t* stats, size_t litLength, const BYTE* literals, size_t offset, size_t matchLength) { (void)stats; (void)litLength; (void)literals; (void)offset; (void)matchLength; }
 #endif
 
 typedef struct {


### PR DESCRIPTION
Remove extraneous semicolons in zstd_internal.h to avoid compiler informational %CC-I-EXTRASEMI, and also to avoid the null statements, the null statements are not causing a problem on these lines, but the EXTRASEMI informational can be useful at detecting places where null statements can cause unexpected behaviour, so it is good to have compilations without this information being generated (these were the only lines that generated it in zstd).